### PR TITLE
Point to forked cordova-plugin-iosrtc repo

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -31,7 +31,7 @@
     <plugin name="cordova-plugin-crosswalk-webview" spec="https://github.com/crosswalk-project/cordova-plugin-crosswalk-webview" />
     <plugin name="cordova-plugin-device" version="^1.0.1" />
     <plugin name="cordova-plugin-camera" spec="https://github.com/eface2face/cordova-plugin-camera" />
-    <plugin name="cordova-plugin-iosrtc" version="^2.0.1" />
+    <plugin name="cordova-plugin-iosrtc" spec="https://github.com/Watchful-Org/cordova-plugin-iosrtc" />
     <preference name="xwalkVersion" value="xwalk_core_library_beta:18+" />
     <preference name="xwalkCommandLine" value="--disable-pull-to-refresh-effect" />
     <preference name="xwalkMode" value="embedded" />


### PR DESCRIPTION
This PR points this forked repo to the forked cordova-plugin-iosrtc so the updates to use Cordova iOS 4.0.1 are applied.
