### PR TITLE
Repositioned and displayed buttons while on call

### DIFF
--- a/www/css/main_override.css
+++ b/www/css/main_override.css
@@ -18,8 +18,13 @@ input, textarea {
 	user-select: auto !important;
 }
 
+#icons {
+	bottom: -15px;
+}
+
 #local-video.active {
 	opacity: 0.85 !important;
+	height: 100%
 }
 
 #mini-video.active {
@@ -28,5 +33,15 @@ input, textarea {
 
 #remote-video.active {
 	opacity: 0.85 !important;
+    height: 100%
 }
 
+#icons {
+    bottom: -15px;
+    left: 20px;
+    position: fixed;
+}
+
+svg {
+  display: inline;
+}

--- a/www/js/apprtc.debug.js
+++ b/www/js/apprtc.debug.js
@@ -354,7 +354,8 @@ AppController.prototype.showRoomSelection_ = function() {
 AppController.prototype.finishCallSetup_ = function(roomId) {
   this.call_.start(roomId);
   document.onkeypress = this.onKeyPress_.bind(this);
-  window.onmousemove = this.showIcons_.bind(this);
+  //window.onmousemove = this.showIcons_.bind(this);
+  window.onclick = this.showIcons_.bind(this);
   $(UI_CONSTANTS.muteAudioSvg).onclick = this.toggleAudioMute_.bind(this);
   $(UI_CONSTANTS.muteVideoSvg).onclick = this.toggleVideoMute_.bind(this);
   $(UI_CONSTANTS.fullscreenSvg).onclick = this.toggleFullScreen_.bind(this);
@@ -582,9 +583,9 @@ AppController.prototype.deactivate_ = function(element) {
 AppController.prototype.showIcons_ = function() {
   if (!this.icons_.classList.contains("active")) {
     this.activate_(this.icons_);
-    setTimeout(function() {
-      this.deactivate_(this.icons_);
-    }.bind(this), 5E3);
+//    setTimeout(function() {
+//      this.deactivate_(this.icons_);
+//    }.bind(this), 5E3);
   }
 };
 AppController.prototype.loadUrlParams_ = function() {


### PR DESCRIPTION
The buttons have been repositioned and enabled for display on the app while on a call. They are also clickable. In addition, while it is still fullscreen video, the video height and image has been added to main_override.css for easy resizing in case the blended video/button is not ideal.
